### PR TITLE
Adding autodj_threshold, autodj_timer, enforcement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,7 @@ for(var avatar in avatars)
 
 var cmbot = function(_options) {
 	var cmbot = this;
-	this.VERSION = '0.9.6';
+	this.VERSION = '0.9.7';
 	
 	this.initOptions(_options);
 	this.currentSong = false;
@@ -124,6 +124,8 @@ var cmbot = function(_options) {
 		loved: false,
 		autodjing: false, // If the bot autodj's, this will get set to true. When someone adds themselves to the queue, the bot will only step down if it automatically stepped up (ie, it won't step down if a mod made it dj manually)
 		autodj: this.options.autodj,
+		autodj_threshold: (this.options.autodj_threshold != null) ? this.options.autodj_threshold : 2, // You should set this in your mybot.js file, but it defaults if you don't
+		autodj_timer: (this.options.autodj_timer != null) ? this.options.autodj_timer : 60, // You should set this in your mybot.js file, but it defaults if you don't
 		snagged: false,
 		stfu: false,
 		max_djs: 5,
@@ -142,7 +144,7 @@ var cmbot = function(_options) {
 			up: [],
 			down: []
 		},
-		enforcement: true, // Queue enforcement
+		enforcement: (this.options.enforcement == 'on' || this.options.enforcement ==  null) ? true : false, // Queue enforcement. You should set this in your mybot.js file, but it defaults if you don't
 		queueTimer: {},
 		lastfm: {
 			enabled: false
@@ -485,6 +487,7 @@ cmbot.prototype.eventRoomChanged = function() {
 		}
 		cmbot.loadPlayCounts();
 		cmbot.autodj();
+		cmbot.stepDown();
 		cmbot.doCustomEvents('roomChanged', data);
 	});
 };
@@ -707,6 +710,7 @@ cmbot.prototype.eventNewSong = function() {
 			return false;
 		}
 		cmbot.session.current_dj = song.djid;
+		cmbot.stepDown();
 		
 		if(cmbot.options.scrobble === true && cmbot.lastfm !== false) {
 			// Set a timer to scrobble this play
@@ -1181,11 +1185,7 @@ cmbot.prototype.eventAddDj = function() {
 		cmbot.checkQueue();
 		if(newDj.userid != cmbot.options.bot.userid) {
 			cmbot.autodj();
-			// Step down if the decks are full
-			if(cmbot.session.djing && (cmbot.session.djs.length == cmbot.session.max_djs) && (!cmbot.session.enforcement || cmbot.isFFA())) {
-				log("Stepping down since the decks are full.");
-				cmbot.bot.remDj(cmbot.options.bot.userid);
-			}
+			cmbot.stepDown();
 		}
 		
 		cmbot.doCustomEvents('add_dj', data);
@@ -1211,7 +1211,7 @@ cmbot.prototype.autodj = function() {
 		log("Setting timer to autodj");
 		cmbot.session.timers.autodj = setTimeout(function() {
 			// Make sure the previous conditions are still true before actually dj'ing
-			if(cmbot.session.max_djs - cmbot.session.djs.length >= 2 && !cmbot.session.djing && cmbot.q.getQueueLength(true) == 0) {
+			if(cmbot.session.max_djs - cmbot.session.djs.length >= cmbot.session.autodj_threshold && !cmbot.session.djing && cmbot.q.getQueueLength(true) == 0) {
 				log("Autodj'ing!");
 				cmbot.bot.addDj(function(result) {
 					if(result.success) {
@@ -1223,7 +1223,40 @@ cmbot.prototype.autodj = function() {
 			}
 			clearTimeout(cmbot.session.timers.autodj);
 			cmbot.session.timers.autodj = false;
-		}, 60*1000);
+		}, cmbot.session.autodj_timer*1000);
+	}
+};
+
+cmbot.prototype.stepDown = function()
+{
+	// Step down if the decks are full
+	var cmbot = this,
+		freeSpots = cmbot.session.max_djs - cmbot.session.djs.length,
+		djing = cmbot.session.djing,
+		djCheck = function(msg)
+		{
+			if(cmbot.session.current_dj == cmbot.options.bot.userid)
+			{
+				msg = "Stepping down after my song";
+				log(msg);
+				cmbot.bot.speak(msg);
+			}
+			else
+			{
+				log(msg);
+				cmbot.bot.speak(msg);
+				cmbot.bot.remDj(cmbot.options.bot.userid);
+			}
+		};
+	log(freeSpots+" freeSpots");
+
+	if(djing && (cmbot.session.djs.length == cmbot.session.max_djs) && (!cmbot.session.enforcement || cmbot.isFFA()))
+	{
+		djCheck("Stepping down since the decks are full.");
+	}
+	else if(djing && (freeSpots+1 < cmbot.session.autodj_threshold))
+	{
+		djCheck("Stepping down since the decks have more DJs than needed for me to DJ.");
 	}
 };
 
@@ -1261,6 +1294,7 @@ cmbot.prototype.eventRemDj = function() {
 		else if(!user.refresh) {
 			cmbot.checkQueue();
 			cmbot.autodj();
+			cmbot.stepDown();
 		}
 
 		user.escortme = false;


### PR DESCRIPTION
Added user options to change the following:
- enforcement (defaults to 'on')
  - This works with 'set_limit', but you can now toggle 'enforcement' without changing the song limit DJ's have.
- autodj_threshold (defaults to 2 open spots, only used if autodj: true)
  - This allows users to set the number of open spots at which the bot should be allowed to autodj. ex: set to '4' so he'll DJ if there's only 1 DJ. He'll detect if the threshold is met, and automatically jump down to make space if he's not DJing, or wait until after his song if he's playing one. 
- autodj_timer (defaults to 60 seconds)
  - Set to your preference. I like 10 seconds personally, so if there's only 1 DJ he'll jump up in time to not interrupt the song playing for the current DJ who's all alone.

You should add these to your mybot.js and customize them to your liking, but they all have defaults in index.js if you don't.

```
autodj_threshold: 2, // Number of open DJ spots needed for the bot to Auto DJ, if 
autodj_timer: 60, // Number of seconds to wait for autodj
enforcement: 'on', // Set enforcement 'on' or 'off'. If it's on, it'll use set_limit for max songs. If 'off', it'll ignore set_limit
```
